### PR TITLE
Fix wrong proto reference in thread type debug log

### DIFF
--- a/src/aiotieba/api/get_posts/_classdef.py
+++ b/src/aiotieba/api/get_posts/_classdef.py
@@ -1017,7 +1017,7 @@ class Thread_p:
 
         type_ = ThreadType(thread_proto.thread_type)
         if type_ == ThreadType.UNKNOWN:
-            LOG().debug("Unknown thread type. tid=%d, type=%s", tid, data_proto.thread_type)
+            LOG().debug("Unknown thread type. tid=%d, type=%s", tid, thread_proto.thread_type)
 
         is_share = bool(thread_proto.is_share_thread)
         view_num = data_proto.thread_freq_num


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "...\.venv\Lib\site-packages\aiotieba\api\get_posts\_classdef.py", line 1020, in from_proto
    LOG().debug("Unknown thread type. tid=%d, type=%s", tid, data_proto.thread_type)
AttributeError: thread_type
```